### PR TITLE
expose isUpgradeable method on mutable tree and unit test

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -52,7 +52,7 @@ func setupExportTreeRandom(t *testing.T) *ImmutableTree {
 		keySize   = 16
 		valueSize = 16
 
-		versions    = 8   // number of versions to generate
+		versions    = 8    // number of versions to generate
 		versionOps  = 1024 // number of operations (create/update/delete) per version
 		updateRatio = 0.4  // ratio of updates out of all operations
 		deleteRatio = 0.2  // ratio of deletes out of all operations

--- a/fast_iterator.go
+++ b/fast_iterator.go
@@ -9,7 +9,7 @@ import (
 var errFastIteratorNilNdbGiven = errors.New("fast iterator must be created with a nodedb but it was nil")
 
 // FastIterator is a dbm.Iterator for ImmutableTree
-// it iterates over the latest state via fast nodes, 
+// it iterates over the latest state via fast nodes,
 // taking advantage of keys being located in sequence in the underlying database.
 type FastIterator struct {
 	start, end []byte

--- a/fast_node_test.go
+++ b/fast_node_test.go
@@ -29,9 +29,9 @@ func TestFastNode_encode_decode(t *testing.T) {
 		"nil":   {nil, "", true},
 		"empty": {&FastNode{}, "0000", false},
 		"inner": {&FastNode{
-			key:       []byte{0x4},
-			versionLastUpdatedAt:   1,
-			value: []byte{0x2},
+			key:                  []byte{0x4},
+			versionLastUpdatedAt: 1,
+			value:                []byte{0x2},
 		}, "020102", false},
 	}
 	for name, tc := range testcases {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -227,7 +227,7 @@ func TestIterator_Basic_Full_Ascending_Success(t *testing.T) {
 	t.Run("Unsaved Fast Iterator", func(t *testing.T) {
 		itr, mirror := setupUnsavedFastIterator(t, config)
 		require.True(t, itr.Valid())
-		require.Equal(t, 25 - 25 / 4 + 1, len(mirror)) // to account for removals
+		require.Equal(t, 25-25/4+1, len(mirror)) // to account for removals
 		performTest(t, itr, mirror)
 	})
 }
@@ -267,7 +267,7 @@ func TestIterator_Basic_Full_Descending_Success(t *testing.T) {
 
 	t.Run("Unsaved Fast Iterator", func(t *testing.T) {
 		itr, mirror := setupUnsavedFastIterator(t, config)
-		require.Equal(t, 25 - 25 / 4 + 1, len(mirror)) // to account for removals
+		require.Equal(t, 25-25/4+1, len(mirror)) // to account for removals
 		require.True(t, itr.Valid())
 		performTest(t, itr, mirror)
 	})
@@ -393,7 +393,7 @@ func setupUnsavedFastIterator(t *testing.T, config *iteratorTestConfig) (dbm.Ite
 
 	if len(mergedMirror) > 0 {
 		// Remove random keys
-		for i := 0; i < len(mergedMirror) / 4; i++ {
+		for i := 0; i < len(mergedMirror)/4; i++ {
 			randIndex := rand.Intn(len(mergedMirror))
 			keyToRemove := mergedMirror[randIndex][0]
 

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -504,14 +504,21 @@ func (tree *MutableTree) LoadVersionForOverwriting(targetVersion int64) (int64, 
 	return latestVersion, nil
 }
 
+// Returns true if the tree may be auto-upgraded, false otherwise
+// An example of when an upgrade may be performed is when we are enaling fast storage for the first time or
+// need to overwrite fast nodes due to mismatch with live state.
+func (tree *MutableTree) IsUpgradeable() bool {
+	return !tree.ndb.hasUpgradedToFastStorage() || tree.ndb.shouldForceFastStorageUpgrade()
+}
+
 // enableFastStorageAndCommitIfNotEnabled if nodeDB doesn't mark fast storage as enabled, enable it, and commit the update.
 // Checks whether the fast cache on disk matches latest live state. If not, deletes all existing fast nodes and repopulates them
 // from latest tree.
 func (tree *MutableTree) enableFastStorageAndCommitIfNotEnabled() (bool, error) {
-	shouldForceUpdate := tree.ndb.shouldForceFastStorageUpdate()
+	shouldForceUpdate := tree.ndb.shouldForceFastStorageUpgrade()
 	isFastStorageEnabled := tree.ndb.hasUpgradedToFastStorage() 
 
-	if  isFastStorageEnabled && !shouldForceUpdate {
+	if !tree.IsUpgradeable() {
 		return false, nil
 	}
 

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -516,7 +516,7 @@ func (tree *MutableTree) IsUpgradeable() bool {
 // from latest tree.
 func (tree *MutableTree) enableFastStorageAndCommitIfNotEnabled() (bool, error) {
 	shouldForceUpdate := tree.ndb.shouldForceFastStorageUpgrade()
-	isFastStorageEnabled := tree.ndb.hasUpgradedToFastStorage() 
+	isFastStorageEnabled := tree.ndb.hasUpgradedToFastStorage()
 
 	if !tree.IsUpgradeable() {
 		return false, nil

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -850,7 +850,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 	// upgrade and then commits them all in the end.
 	updatedExpectedStorageVersion := make([]byte, len(expectedStorageVersion))
 	copy(updatedExpectedStorageVersion, expectedStorageVersion)
-	updatedExpectedStorageVersion[len(updatedExpectedStorageVersion) - 1]++
+	updatedExpectedStorageVersion[len(updatedExpectedStorageVersion)-1]++
 	batchMock.EXPECT().Delete(fastKeyFormat.Key(fastNodeKeyToDelete)).Return(nil).Times(1)
 	batchMock.EXPECT().Set(metadataKeyFormat.Key([]byte(storageVersionKey)), updatedExpectedStorageVersion).Return(nil).Times(1)
 	batchMock.EXPECT().Write().Return(nil).Times(1)

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -678,9 +678,11 @@ func TestUpgradeStorageToFast_LatestVersion_Success(t *testing.T) {
 	randomizeTreeAndMirror(t, tree, mirror)
 
 	// Enable fast storage
+	require.True(t, tree.IsUpgradeable())
 	enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
 	require.NoError(t, err)
 	require.True(t, enabled)
+	require.False(t, tree.IsUpgradeable())
 
 	require.True(t, tree.IsFastCacheEnabled())
 }
@@ -699,10 +701,12 @@ func TestUpgradeStorageToFast_AlreadyUpgraded_Success(t *testing.T) {
 	randomizeTreeAndMirror(t, tree, mirror)
 
 	// Enable fast storage
+	require.True(t, tree.IsUpgradeable())
 	enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
 	require.NoError(t, err)
 	require.True(t, enabled)
 	require.True(t, tree.IsFastCacheEnabled())
+	require.False(t, tree.IsUpgradeable())
 
 	// Test enabling fast storage when already enabled
 	enabled, err = tree.enableFastStorageAndCommitIfNotEnabled()
@@ -799,7 +803,7 @@ func TestFastStorageReUpgradeProtection_NoForceUpgrade_Success(t *testing.T) {
 
 	// Ensure that the right branch of enableFastStorageAndCommitIfNotEnabled will be triggered
 	require.True(t, tree.IsFastCacheEnabled())
-	require.False(t, tree.ndb.shouldForceFastStorageUpdate())
+	require.False(t, tree.ndb.shouldForceFastStorageUpgrade())
 
 	enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
 	require.NoError(t, err)
@@ -886,7 +890,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 
 	// Ensure that the right branch of enableFastStorageAndCommitIfNotEnabled will be triggered
 	require.True(t, tree.IsFastCacheEnabled())
-	require.True(t, tree.ndb.shouldForceFastStorageUpdate())
+	require.True(t, tree.ndb.shouldForceFastStorageUpgrade())
 
 	// Actual method under test
 	enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
@@ -904,16 +908,19 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 	tree, mirror := setupTreeAndMirrorForUpgrade(t)
 
 	require.False(t, tree.IsFastCacheEnabled())
+	require.True(t, tree.IsUpgradeable())
 
 	// Should auto enable in save version
 	_, _, err := tree.SaveVersion()
 	require.NoError(t, err)
 
 	require.True(t, tree.IsFastCacheEnabled())
+	require.False(t, tree.IsUpgradeable())
 
 	sut, _ := NewMutableTree(tree.ndb.db, 1000)
 
 	require.False(t, sut.IsFastCacheEnabled())
+	require.False(t, sut.IsUpgradeable()) // upgraded in save version
 
 	// Load version - should auto enable fast storage
 	version, err := sut.Load()
@@ -954,16 +961,19 @@ func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T)
 	tree, mirror := setupTreeAndMirrorForUpgrade(t)
 
 	require.False(t, tree.IsFastCacheEnabled())
+	require.True(t, tree.IsUpgradeable())
 
 	// Should auto enable in save version
 	_, _, err := tree.SaveVersion()
 	require.NoError(t, err)
 
 	require.True(t, tree.IsFastCacheEnabled())
+	require.False(t, tree.IsUpgradeable())
 
 	sut, _ := NewMutableTree(tree.ndb.db, 1000)
 
 	require.False(t, sut.IsFastCacheEnabled())
+	require.False(t, sut.IsUpgradeable()) // upgraded in save version
 
 	// LazyLoadVersion - should auto enable fast storage
 	version, err := sut.LazyLoadVersion(1)

--- a/nodedb.go
+++ b/nodedb.go
@@ -62,7 +62,7 @@ var (
 	rootKeyFormat = NewKeyFormat('r', int64Size) // r<version>
 )
 
-var(
+var (
 	errInvalidFastStorageVersion = fmt.Sprintf("Fast storage version must be in the format <storage version>%s<latest fast cache version>", fastStorageVersionDelimiter)
 )
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -253,16 +253,16 @@ func (ndb *nodeDB) getStorageVersion() string {
 	return ndb.storageVersion
 }
 
-// Returns true if the upgrade to fast storage has occurred, false otherwise.
+// Returns true if the upgrade to latest storage version has been performed, false otherwise.
 func (ndb *nodeDB) hasUpgradedToFastStorage() bool {
 	return ndb.getStorageVersion() >= fastStorageVersionValue
 }
 
 // Returns true if the upgrade to fast storage has occurred but it does not match the live state, false otherwise.
 // When the live state is not matched, we must force reupgrade.
-// We determine this by checking the version of the live state and the version of the live state wheb
-// fast storage was updated on disk the last time.
-func (ndb *nodeDB) shouldForceFastStorageUpdate() bool {
+// We determine this by checking the version of the live state and the version of the live state when
+// latest storage was updated on disk the last time.
+func (ndb *nodeDB) shouldForceFastStorageUpgrade() bool {
 	versions := strings.Split(ndb.storageVersion, fastStorageVersionDelimiter)
 
 	if len(versions) == 2 {

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -185,7 +185,7 @@ func TestShouldForceFastStorageUpdate_DefaultVersion_True(t *testing.T) {
 	ndb.storageVersion = defaultStorageVersionValue
 	ndb.latestVersion = 100
 
-	require.False(t, ndb.shouldForceFastStorageUpdate())
+	require.False(t, ndb.shouldForceFastStorageUpgrade())
 }
 
 func TestShouldForceFastStorageUpdate_FastVersion_Greater_True(t *testing.T) {
@@ -194,7 +194,7 @@ func TestShouldForceFastStorageUpdate_FastVersion_Greater_True(t *testing.T) {
 	ndb.latestVersion = 100
 	ndb.storageVersion = fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion + 1))
 
-	require.True(t, ndb.shouldForceFastStorageUpdate())
+	require.True(t, ndb.shouldForceFastStorageUpgrade())
 }
 
 func TestShouldForceFastStorageUpdate_FastVersion_Smaller_True(t *testing.T) {
@@ -203,7 +203,7 @@ func TestShouldForceFastStorageUpdate_FastVersion_Smaller_True(t *testing.T) {
 	ndb.latestVersion = 100
 	ndb.storageVersion = fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion - 1))
 
-	require.True(t, ndb.shouldForceFastStorageUpdate())
+	require.True(t, ndb.shouldForceFastStorageUpgrade())
 }
 
 func TestShouldForceFastStorageUpdate_FastVersion_Match_False(t *testing.T) {
@@ -212,7 +212,7 @@ func TestShouldForceFastStorageUpdate_FastVersion_Match_False(t *testing.T) {
 	ndb.latestVersion = 100
 	ndb.storageVersion = fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion))
 
-	require.False(t, ndb.shouldForceFastStorageUpdate())
+	require.False(t, ndb.shouldForceFastStorageUpgrade())
 }
 
 func TestIsFastStorageEnabled_True(t *testing.T) {
@@ -230,7 +230,7 @@ func TestIsFastStorageEnabled_False(t *testing.T) {
 	ndb.latestVersion = 100
 	ndb.storageVersion = defaultStorageVersionValue
 
-	require.False(t, ndb.shouldForceFastStorageUpdate())
+	require.False(t, ndb.shouldForceFastStorageUpgrade())
 }
 
 func makeHashes(b *testing.B, seed int64) [][]byte {

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -79,7 +79,7 @@ func TestSetStorageVersion_Success(t *testing.T) {
 
 	err := ndb.setFastStorageVersionToBatch()
 	require.NoError(t, err)
-	require.Equal(t, expectedVersion + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.getLatestVersion())), string(ndb.getStorageVersion()))
+	require.Equal(t, expectedVersion+fastStorageVersionDelimiter+strconv.Itoa(int(ndb.getLatestVersion())), string(ndb.getStorageVersion()))
 	ndb.batch.Write()
 }
 
@@ -88,7 +88,7 @@ func TestSetStorageVersion_DBFailure_OldKept(t *testing.T) {
 	dbMock := mock.NewMockDB(ctrl)
 	batchMock := mock.NewMockBatch(ctrl)
 	rIterMock := mock.NewMockIterator(ctrl)
-	
+
 	expectedErrorMsg := "some db error"
 
 	expectedFastCacheVersion := 2
@@ -102,7 +102,7 @@ func TestSetStorageVersion_DBFailure_OldKept(t *testing.T) {
 	rIterMock.EXPECT().Close().Return(nil).Times(1)
 
 	dbMock.EXPECT().ReverseIterator(gomock.Any(), gomock.Any()).Return(rIterMock, nil).Times(1)
-	batchMock.EXPECT().Set([]byte(metadataKeyFormat.Key([]byte(storageVersionKey))), []byte(fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(expectedFastCacheVersion))).Return(errors.New(expectedErrorMsg)).Times(1)
+	batchMock.EXPECT().Set([]byte(metadataKeyFormat.Key([]byte(storageVersionKey))), []byte(fastStorageVersionValue+fastStorageVersionDelimiter+strconv.Itoa(expectedFastCacheVersion))).Return(errors.New(expectedErrorMsg)).Times(1)
 
 	ndb := newNodeDB(dbMock, 0, nil)
 	require.Equal(t, defaultStorageVersionValue, string(ndb.getStorageVersion()))
@@ -117,7 +117,7 @@ func TestSetStorageVersion_InvalidVersionFailure_OldKept(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	dbMock := mock.NewMockDB(ctrl)
 	batchMock := mock.NewMockBatch(ctrl)
-	
+
 	expectedErrorMsg := errInvalidFastStorageVersion
 
 	invalidStorageVersion := fastStorageVersionValue + fastStorageVersionDelimiter + "1" + fastStorageVersionDelimiter + "2"
@@ -142,7 +142,7 @@ func TestSetStorageVersion_FastVersionFirst_VersionAppended(t *testing.T) {
 
 	err := ndb.setFastStorageVersionToBatch()
 	require.NoError(t, err)
-	require.Equal(t, fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion)), ndb.storageVersion)
+	require.Equal(t, fastStorageVersionValue+fastStorageVersionDelimiter+strconv.Itoa(int(ndb.latestVersion)), ndb.storageVersion)
 }
 
 func TestSetStorageVersion_FastVersionSecond_VersionAppended(t *testing.T) {
@@ -151,12 +151,12 @@ func TestSetStorageVersion_FastVersionSecond_VersionAppended(t *testing.T) {
 	ndb.latestVersion = 100
 
 	storageVersionBytes := []byte(fastStorageVersionValue)
-	storageVersionBytes[len(fastStorageVersionValue) - 1]++ // increment last byte
+	storageVersionBytes[len(fastStorageVersionValue)-1]++ // increment last byte
 	ndb.storageVersion = string(storageVersionBytes)
 
 	err := ndb.setFastStorageVersionToBatch()
 	require.NoError(t, err)
-	require.Equal(t, string(storageVersionBytes) + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion)), ndb.storageVersion)
+	require.Equal(t, string(storageVersionBytes)+fastStorageVersionDelimiter+strconv.Itoa(int(ndb.latestVersion)), ndb.storageVersion)
 }
 
 func TestSetStorageVersion_SameVersionTwice(t *testing.T) {
@@ -165,12 +165,12 @@ func TestSetStorageVersion_SameVersionTwice(t *testing.T) {
 	ndb.latestVersion = 100
 
 	storageVersionBytes := []byte(fastStorageVersionValue)
-	storageVersionBytes[len(fastStorageVersionValue) - 1]++ // increment last byte
+	storageVersionBytes[len(fastStorageVersionValue)-1]++ // increment last byte
 	ndb.storageVersion = string(storageVersionBytes)
 
 	err := ndb.setFastStorageVersionToBatch()
 	require.NoError(t, err)
-	newStorageVersion := string(storageVersionBytes) + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion)) 
+	newStorageVersion := string(storageVersionBytes) + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion))
 	require.Equal(t, newStorageVersion, ndb.storageVersion)
 
 	err = ndb.setFastStorageVersionToBatch()
@@ -192,7 +192,7 @@ func TestShouldForceFastStorageUpdate_FastVersion_Greater_True(t *testing.T) {
 	db := db.NewMemDB()
 	ndb := newNodeDB(db, 0, nil)
 	ndb.latestVersion = 100
-	ndb.storageVersion = fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion + 1))
+	ndb.storageVersion = fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion+1))
 
 	require.True(t, ndb.shouldForceFastStorageUpgrade())
 }
@@ -201,7 +201,7 @@ func TestShouldForceFastStorageUpdate_FastVersion_Smaller_True(t *testing.T) {
 	db := db.NewMemDB()
 	ndb := newNodeDB(db, 0, nil)
 	ndb.latestVersion = 100
-	ndb.storageVersion = fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion - 1))
+	ndb.storageVersion = fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(ndb.latestVersion-1))
 
 	require.True(t, ndb.shouldForceFastStorageUpgrade())
 }

--- a/proof_ics23_test.go
+++ b/proof_ics23_test.go
@@ -72,7 +72,7 @@ func TestGetNonMembership(t *testing.T) {
 		"big right":    {size: 5431, loc: Right},
 	}
 
-	performTest := func (tree *MutableTree, allKeys [][]byte, loc Where)  {
+	performTest := func(tree *MutableTree, allKeys [][]byte, loc Where) {
 		key := GetNonKey(allKeys, loc)
 
 		proof, err := tree.GetNonMembershipProof(key)
@@ -87,7 +87,7 @@ func TestGetNonMembership(t *testing.T) {
 
 	for name, tc := range cases {
 		tc := tc
-		t.Run("fast-" + name, func (t *testing.T)  {
+		t.Run("fast-"+name, func(t *testing.T) {
 			tree, allkeys, err := BuildTree(tc.size, 0)
 			require.NoError(t, err, "Creating tree: %+v", err)
 			// Save version to enable fast cache
@@ -99,11 +99,10 @@ func TestGetNonMembership(t *testing.T) {
 			performTest(tree, allkeys, tc.loc)
 		})
 
-		t.Run("regular-" + name, func (t *testing.T)  {
+		t.Run("regular-"+name, func(t *testing.T) {
 			tree, allkeys, err := BuildTree(tc.size, 0)
 			require.NoError(t, err, "Creating tree: %+v", err)
 			require.False(t, tree.IsFastCacheEnabled())
-
 
 			performTest(tree, allkeys, tc.loc)
 		})
@@ -111,10 +110,10 @@ func TestGetNonMembership(t *testing.T) {
 }
 
 func BenchmarkGetNonMembership(b *testing.B) {
-	cases := []struct{
+	cases := []struct {
 		size int
 		loc  Where
-		} {
+	}{
 		{size: 100, loc: Left},
 		{size: 100, loc: Middle},
 		{size: 100, loc: Right},
@@ -123,7 +122,7 @@ func BenchmarkGetNonMembership(b *testing.B) {
 		{size: 5431, loc: Right},
 	}
 
-	performTest := func (tree *MutableTree, allKeys [][]byte, loc Where)  {
+	performTest := func(tree *MutableTree, allKeys [][]byte, loc Where) {
 		key := GetNonKey(allKeys, loc)
 
 		proof, err := tree.GetNonMembershipProof(key)
@@ -138,11 +137,9 @@ func BenchmarkGetNonMembership(b *testing.B) {
 		b.StartTimer()
 	}
 
+	b.Run("fast", func(b *testing.B) {
 
-
-	b.Run("fast", func (b *testing.B)  {
-		
-		for i:= 0; i < b.N; i++ {
+		for i := 0; i < b.N; i++ {
 			b.StopTimer()
 			caseIdx := rand.Intn(len(cases))
 			tc := cases[caseIdx]
@@ -152,17 +149,16 @@ func BenchmarkGetNonMembership(b *testing.B) {
 			// Save version to enable fast cache
 			_, _, err = tree.SaveVersion()
 			require.NoError(b, err)
-	
+
 			require.True(b, tree.IsFastCacheEnabled())
 			b.StartTimer()
 			performTest(tree, allkeys, tc.loc)
 		}
 
-
 	})
 
-	b.Run("regular", func (b *testing.B)  {
-		for i:= 0; i < b.N; i++ {
+	b.Run("regular", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
 			b.StopTimer()
 			caseIdx := rand.Intn(len(cases))
 			tc := cases[caseIdx]
@@ -170,7 +166,7 @@ func BenchmarkGetNonMembership(b *testing.B) {
 			tree, allkeys, err := BuildTree(tc.size, 100000)
 			require.NoError(b, err, "Creating tree: %+v", err)
 			require.False(b, tree.IsFastCacheEnabled())
-	
+
 			b.StartTimer()
 			performTest(tree, allkeys, tc.loc)
 		}

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -282,7 +282,7 @@ func assertIterator(t *testing.T, itr dbm.Iterator, mirror [][]string, ascending
 	increment := 1
 	mirrorIdx := startIdx
 
-        // flip the iteration order over mirror if descending
+	// flip the iteration order over mirror if descending
 	if !ascending {
 		startIdx = endIdx - 1
 		endIdx = -1

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -353,7 +353,7 @@ func assertEmptyDatabase(t *testing.T, tree *MutableTree) {
 
 	storageVersionValue, err := tree.ndb.db.Get([]byte(firstKey))
 	require.NoError(t, err)
-	require.Equal(t, fastStorageVersionValue + fastStorageVersionDelimiter + strconv.Itoa(int(tree.ndb.getLatestVersion())), string(storageVersionValue))
+	require.Equal(t, fastStorageVersionValue+fastStorageVersionDelimiter+strconv.Itoa(int(tree.ndb.getLatestVersion())), string(storageVersionValue))
 
 	var foundVersion int64
 	rootKeyFormat.Scan([]byte(secondKey), &foundVersion)

--- a/unsaved_fast_iterator.go
+++ b/unsaved_fast_iterator.go
@@ -15,7 +15,7 @@ var (
 )
 
 // UnsavedFastIterator is a dbm.Iterator for ImmutableTree
-// it iterates over the latest state via fast nodes, 
+// it iterates over the latest state via fast nodes,
 // taking advantage of keys being located in sequence in the underlying database.
 type UnsavedFastIterator struct {
 	start, end []byte
@@ -31,7 +31,7 @@ type UnsavedFastIterator struct {
 	unsavedFastNodeAdditions map[string]*FastNode
 
 	unsavedFastNodeRemovals map[string]interface{}
-	
+
 	unsavedFastNodesToSort []string
 
 	nextKey []byte
@@ -48,18 +48,18 @@ var _ dbm.Iterator = &UnsavedFastIterator{}
 func NewUnsavedFastIterator(start, end []byte, ascending bool, ndb *nodeDB, unsavedFastNodeAdditions map[string]*FastNode, unsavedFastNodeRemovals map[string]interface{}) *UnsavedFastIterator {
 
 	iter := &UnsavedFastIterator{
-		start:        start,
-		end:          end,
-		err:          nil,
-		ascending:    ascending,
-		ndb:          ndb,
+		start:                    start,
+		end:                      end,
+		err:                      nil,
+		ascending:                ascending,
+		ndb:                      ndb,
 		unsavedFastNodeAdditions: unsavedFastNodeAdditions,
-		unsavedFastNodeRemovals: unsavedFastNodeRemovals,
-		unsavedFastNodesToSort: make([]string, 0),
-		nextKey: nil,
-		nextVal: nil,
-		nextUnsavedNodeIdx: 0,
-		fastIterator: NewFastIterator(start, end, ascending, ndb),
+		unsavedFastNodeRemovals:  unsavedFastNodeRemovals,
+		unsavedFastNodesToSort:   make([]string, 0),
+		nextKey:                  nil,
+		nextVal:                  nil,
+		nextUnsavedNodeIdx:       0,
+		fastIterator:             NewFastIterator(start, end, ascending, ndb),
 	}
 
 	// We need to ensure that we iterate over saved and unsaved state in order.
@@ -78,7 +78,7 @@ func NewUnsavedFastIterator(start, end []byte, ascending bool, ndb *nodeDB, unsa
 	}
 
 	sort.Slice(iter.unsavedFastNodesToSort, func(i, j int) bool {
-		if ascending{
+		if ascending {
 			return iter.unsavedFastNodesToSort[i] < iter.unsavedFastNodesToSort[j]
 		} else {
 			return iter.unsavedFastNodesToSort[i] > iter.unsavedFastNodesToSort[j]
@@ -206,7 +206,7 @@ func (iter *UnsavedFastIterator) Next() {
 	}
 
 	// if only unsaved nodes are left, we can just iterate
-	if iter.nextUnsavedNodeIdx < len(iter.unsavedFastNodesToSort)  {
+	if iter.nextUnsavedNodeIdx < len(iter.unsavedFastNodesToSort) {
 		nextUnsavedKey := iter.unsavedFastNodesToSort[iter.nextUnsavedNodeIdx]
 		nextUnsavedNode := iter.unsavedFastNodeAdditions[nextUnsavedKey]
 


### PR DESCRIPTION
**Background**

We would like to expose a method to determine whether an upgrade may be performed. This is useful to use on the SDK side to be able to `info` log the upgrade in progress so that users are aware of it happening. Otherwise, it may take more than 30 minutes to complete and leave users thinking that the SDK is stuck.

**Acceptance Criteria**
- [x] `isUpgradeable` method is exposed
- [x] unit tested 