### PR TITLE
fix bug fatal error: concurrent map read and map write

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -789,7 +789,6 @@ func (tree *MutableTree) getUnsavedFastNodeRemovals() map[string]interface{} {
 func (tree *MutableTree) addUnsavedAddition(key []byte, node *FastNode) {
 	delete(tree.unsavedFastNodeRemovals, string(key))
 	tree.unsavedFastNodeAdditions[string(key)] = node
-	tree.ndb.cacheFastNode(node)
 }
 
 func (tree *MutableTree) saveFastNodeAdditions() error {
@@ -810,7 +809,6 @@ func (tree *MutableTree) saveFastNodeAdditions() error {
 func (tree *MutableTree) addUnsavedRemoval(key []byte) {
 	delete(tree.unsavedFastNodeAdditions, string(key))
 	tree.unsavedFastNodeRemovals[string(key)] = true
-	tree.ndb.uncacheFastNode(key)
 }
 
 func (tree *MutableTree) saveFastNodeRemovals() error {


### PR DESCRIPTION
**Background**

Creating a block explorer on archive node seems to be causing fatal errors: #22 

The logs indicate that there was a grpc query to the SDK that got propagated to IAVL while in a separate goroutine the ndoe was committing:

https://gist.github.com/rkben/8814376162cda8c08dd33d60f6933429#file-cleand_osmo-log-L1257 - this goroutine seems to be committing a block
https://gist.github.com/rkben/8814376162cda8c08dd33d60f6933429#file-cleand_osmo-log-L268 - this goroutine seems to be handling the grpc query


Initial investigation points at the fact that [`fastNodeCache`](https://github.com/osmosis-labs/iavl/blob/dev/iavl_data_locality/nodedb.go#L82) is not being synchronized correctly.

**In this PR**
- ensured that `fastNodeCache` cache is only accessed from within `nodedb`
- access to `fastNodeCache` in `nodedb` is synchronized 
- comments added, reminding about the need for synchrony
- all tests pass and no deadlock
- created a ticket to refactor synchrony: 