### PR TITLE
avoid clearing fast node cache during pruning

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -525,7 +525,6 @@ func (ndb *nodeDB) DeleteVersionsRange(fromVersion, toVersion int64) error {
 					panic(err)
 				}
 				ndb.uncacheNode(hash)
-				ndb.uncacheFastNode(key)
 			} else {
 				ndb.saveOrphan(hash, from, predecessor)
 			}
@@ -533,14 +532,6 @@ func (ndb *nodeDB) DeleteVersionsRange(fromVersion, toVersion int64) error {
 		})
 		if err != nil {
 			return err
-		}
-	}
-
-	for key, elem := range ndb.fastNodeCache {
-		fastNode := elem.Value.(*FastNode)
-		if fastNode.versionLastUpdatedAt >= fromVersion && fastNode.versionLastUpdatedAt < toVersion {
-			ndb.fastNodeCacheQueue.Remove(elem)
-			delete(ndb.fastNodeCache, string(key))
 		}
 	}
 


### PR DESCRIPTION
**Background**

Fast node cache represents latest live state. As a result, the fast nodes should only be deleted on calls to `Remove()`. We should not clear cache during pruning if the fast node was created at the pruned height.

Functionally, there is no change because we still kept the fast nodes on disk despite clearing the cache. It simply does not make sense clearing the cache during pruning with the current abstraction.

Benchstat does not show significant changes:
```
benchstat old.log new.log
name                                                                  old time/op    new time/op    delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16    2.90µs ± 8%    3.03µs ± 8%    ~     (p=0.310 n=5+5)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16    9.81µs ± 3%    9.84µs ± 2%    ~     (p=0.548 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                     333ns ± 3%     359ns ± 8%    ~     (p=0.056 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                    13.0µs ± 3%    13.3µs ± 4%    ~     (p=0.222 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                     63.4ms ± 4%    63.5ms ± 7%    ~     (p=0.841 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      1.21s ±12%     1.27s ± 2%    ~     (p=0.111 n=5+4)
Medium/goleveldb-100000-100-16-40/update-16                              173µs ±21%     186µs ±20%    ~     (p=0.310 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                              24.1ms ±11%    24.8ms ± 7%    ~     (p=0.421 n=5+5)

name                                                                  old alloc/op   new alloc/op   delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16      814B ± 0%      814B ± 0%    ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16    1.41kB ± 0%    1.41kB ± 1%    ~     (p=0.460 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                     0.00B          0.00B         ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                    2.00kB ± 0%    1.99kB ± 0%  -0.31%  (p=0.024 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                     29.3MB ± 0%    29.3MB ± 0%    ~     (p=0.841 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      276MB ± 0%     276MB ± 0%    ~     (p=0.200 n=4+4)
Medium/goleveldb-100000-100-16-40/update-16                             51.4kB ± 7%    52.7kB ± 7%    ~     (p=0.548 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                              6.40MB ± 6%    6.46MB ± 4%    ~     (p=0.548 n=5+5)

name                                                                  old allocs/op  new allocs/op  delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16      16.0 ± 0%      16.0 ± 0%    ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16      24.0 ± 0%      24.0 ± 0%    ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                      0.00           0.00         ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                      34.0 ± 0%      34.0 ± 0%    ~     (all equal)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                       523k ± 0%      523k ± 0%    ~     (p=1.000 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      4.71M ± 0%     4.71M ± 0%    ~     (p=0.257 n=4+4)
Medium/goleveldb-100000-100-16-40/update-16                                555 ±14%       575 ±14%    ~     (p=0.548 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                               72.5k ± 5%     73.4k ± 4%    ~     (p=0.421 n=5+5)
```