### PR TITLE
fix data race related to VersionExists

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -35,7 +35,7 @@ type MutableTree struct {
 	unsavedFastNodeRemovals  map[string]interface{} // FastNodes that have not yet been removed from disk
 	ndb                      *nodeDB
 
-	mtx sync.RWMutex // versions Read/write lock.
+	mtx sync.Mutex
 }
 
 // NewMutableTree returns a new tree with the specified cache size and datastore.
@@ -86,8 +86,8 @@ func (tree *MutableTree) VersionExists(version int64) bool {
 
 // AvailableVersions returns all available versions in ascending order
 func (tree *MutableTree) AvailableVersions() []int {
-	tree.mtx.RLock()
-	defer tree.mtx.RUnlock()
+	tree.mtx.Lock()
+	defer tree.mtx.Unlock()
 
 	res := make([]int, 0, len(tree.versions))
 	for i, v := range tree.versions {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -68,8 +68,8 @@ func (tree *MutableTree) IsEmpty() bool {
 
 // VersionExists returns whether or not a version exists.
 func (tree *MutableTree) VersionExists(version int64) bool {
-	tree.mtx.RLock()
-	defer tree.mtx.RUnlock()
+	tree.mtx.Lock()
+	defer tree.mtx.Unlock()
 
 	if tree.allRootLoaded {
 		return tree.versions[version]


### PR DESCRIPTION
**Background**

@czarcas7ic reminded me of the race tests in the SDK. So after checking the new snapshot/pruning PR - https://github.com/osmosis-labs/cosmos-sdk/pull/140, I found one failing. Interestingly, it was never failing prior to that PR. Apparently, the refactor allowed us to detect it.

The problem was in `VersionExists` where we were using an `RLock` while modifying a common resource. The only other method where using `RLock` still made sense was `AvailableVersions()`. However, since it is the only one and is not used frequently, I made a guess that performance overhead from having an `RWLock` would be greater than from having a regular `Lock` everywhere:
```
name                                                                  old time/op    new time/op    delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16    3.07µs ± 8%    2.97µs ± 3%    ~     (p=0.421 n=5+5)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16    10.0µs ± 3%    10.1µs ± 5%    ~     (p=0.222 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                     355ns ± 6%     338ns ± 2%  -4.82%  (p=0.016 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                    13.6µs ± 3%    13.4µs ± 3%    ~     (p=0.421 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                     63.1ms ± 5%    66.9ms ± 6%    ~     (p=0.151 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      1.28s ±10%     1.23s ± 1%    ~     (p=0.190 n=5+4)
Medium/goleveldb-100000-100-16-40/update-16                              178µs ±21%     172µs ±19%    ~     (p=0.690 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                              23.6ms ± 4%    23.1ms ± 5%    ~     (p=0.421 n=5+5)

name                                                                  old alloc/op   new alloc/op   delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16      814B ± 0%      814B ± 0%    ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16    1.41kB ± 1%    1.41kB ± 1%    ~     (p=0.222 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                     0.00B          0.00B         ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                    1.99kB ± 0%    1.99kB ± 0%    ~     (p=0.714 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                     29.3MB ± 0%    29.3MB ± 0%    ~     (p=0.333 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      276MB ± 0%     276MB ± 0%  +0.02%  (p=0.029 n=4+4)
Medium/goleveldb-100000-100-16-40/update-16                             51.9kB ± 8%    51.7kB ± 9%    ~     (p=1.000 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                              6.46MB ± 3%    6.33MB ± 1%    ~     (p=0.151 n=5+5)

name                                                                  old allocs/op  new allocs/op  delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16      16.0 ± 0%      16.0 ± 0%    ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16      24.0 ± 0%      24.0 ± 0%    ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                      0.00           0.00         ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                      34.0 ± 0%      33.6 ± 2%    ~     (p=0.333 n=4+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                       523k ± 0%      523k ± 0%    ~     (p=0.238 n=4+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      4.71M ± 0%     4.71M ± 0%    ~     (p=0.200 n=4+4)
Medium/goleveldb-100000-100-16-40/update-16                                559 ±15%       562 ±17%    ~     (p=0.841 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                               72.5k ± 3%     71.9k ± 2%    ~     (p=0.548 n=5+5)
```

Confirmed that this change in conjunction with another SDK side change fixes the race.

This might be related to the app hash bug because this `VersionExists` method is used during commit, some queries, and proofs. However, it is impossible to tell for sure if this was the true cause.

The failing race test:
```
roman@akhtariev:~/projects/cosmos-sdk (roman/snap-prune)$ go test -timeout 30s -run ^TestLoadVersionPruning$ github.com/cosmos/cosmos-sdk/baseapp -race
==================
WARNING: DATA RACE
Read at 0x00c000e81ce0 by goroutine 49:
  runtime.mapaccess2_fast64()
      /usr/local/go/src/runtime/map_fast64.go:52 +0x0
  github.com/cosmos/iavl.(*MutableTree).VersionExists()
      /home/roman/projects/cosmos-sdk/vendor/github.com/cosmos/iavl/mutable_tree.go:78 +0x104
  github.com/cosmos/cosmos-sdk/store/iavl.(*Store).VersionExists()
      /home/roman/projects/cosmos-sdk/store/iavl/store.go:160 +0x51
  github.com/cosmos/cosmos-sdk/store/iavl.(*Store).GetImmutable()
      /home/roman/projects/cosmos-sdk/store/iavl/store.go:108 +0x54
  github.com/cosmos/cosmos-sdk/store/iavl.(*Store).Export()
      /home/roman/projects/cosmos-sdk/store/iavl/store.go:239 +0x4b
  github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).Snapshot.func2()
      /home/roman/projects/cosmos-sdk/store/rootmulti/store.go:729 +0x68e

Previous write at 0x00c000e81ce0 by goroutine 36:
  runtime.mapassign_fast64()
      /usr/local/go/src/runtime/map_fast64.go:92 +0x0
  github.com/cosmos/iavl.(*MutableTree).VersionExists()
      /home/roman/projects/cosmos-sdk/vendor/github.com/cosmos/iavl/mutable_tree.go:83 +0x1b2
  github.com/cosmos/iavl.(*MutableTree).SaveVersion()
      /home/roman/projects/cosmos-sdk/vendor/github.com/cosmos/iavl/mutable_tree.go:701 +0x14a
  github.com/cosmos/cosmos-sdk/store/iavl.(*Store).Commit()
      /home/roman/projects/cosmos-sdk/store/iavl/store.go:127 +0x139
  github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).commitStores()
      /home/roman/projects/cosmos-sdk/store/rootmulti/store.go:968 +0x18b
  github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).Commit()
      /home/roman/projects/cosmos-sdk/store/rootmulti/store.go:406 +0x153
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Commit()
      /home/roman/projects/cosmos-sdk/baseapp/abci.go:308 +0x303
  github.com/cosmos/cosmos-sdk/baseapp.TestLoadVersionPruning()
      /home/roman/projects/cosmos-sdk/baseapp/baseapp_test.go:437 +0xa14
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47

Goroutine 49 (running) created at:
  github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).Snapshot()
      /home/roman/projects/cosmos-sdk/store/rootmulti/store.go:696 +0x729
  github.com/cosmos/cosmos-sdk/snapshots.(*Manager).Create()
      /home/roman/projects/cosmos-sdk/snapshots/manager.go:158 +0x217
  github.com/cosmos/cosmos-sdk/snapshots.(*Manager).snapshot()
      /home/roman/projects/cosmos-sdk/snapshots/manager.go:317 +0x168
  github.com/cosmos/cosmos-sdk/snapshots.(*Manager).SnapshotIfApplicable·dwrap·9()
      /home/roman/projects/cosmos-sdk/snapshots/manager.go:306 +0x47

Goroutine 36 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1306 +0x726
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1598 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1596 +0x7ca
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1504 +0x9d1
  main.main()
      _testmain.go:147 +0x22b
==================
--- FAIL: TestLoadVersionPruning (0.02s)
    testing.go:1152: race detected during execution of test
FAIL
FAIL    github.com/cosmos/cosmos-sdk/baseapp    0.523s
FAIL
```