### PR TITLE
implement cache abstraction and unit test

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -46,21 +46,21 @@ func New(cacheLimit int) Cache {
 	}
 }
 
-func (nc *lruCache) Add(node Node) Node {
-	if e, exists := nc.dict[string(node.GetKey())]; exists {
-		nc.ll.MoveToFront(e)
+func (c *lruCache) Add(node Node) Node {
+	if e, exists := c.dict[string(node.GetKey())]; exists {
+		c.ll.MoveToFront(e)
 		old := e.Value
 		e.Value = node
 		return old.(Node)
 	}
 
-	elem := nc.ll.PushFront(node)
-	nc.dict[string(node.GetKey())] = elem
+	elem := c.ll.PushFront(node)
+	c.dict[string(node.GetKey())] = elem
 
-	if nc.ll.Len() > nc.cacheLimit {
-		oldest := nc.ll.Back()
+	if c.ll.Len() > c.cacheLimit {
+		oldest := c.ll.Back()
 
-		return nc.remove(oldest)
+		return c.remove(oldest)
 	}
 	return nil
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -4,10 +4,12 @@ import (
 	"container/list"
 )
 
+// Node represents a node eligible for caching.
 type Node interface {
 	GetKey() []byte
 }
 
+// Cache is an in-memory structure to persist nodes for quick access.
 type Cache interface {
 	// Adds node to cache. If full and had to remove the oldest element,
 	// returns the oldest, otherwise nil.
@@ -27,11 +29,11 @@ type Cache interface {
 	Len() int
 }
 
-// lruCache is an LRU cache implementeation.
+// lruCache is an LRU cache implementation.
 type lruCache struct {
 	dict       map[string]*list.Element // FastNode cache.
 	cacheLimit int                      // FastNode cache size limit in elements.
-	ll      *list.List               // LRU queue of cache elements. Used for deletion.
+	ll         *list.List               // LRU queue of cache elements. Used for deletion.
 }
 
 var _ Cache = (*lruCache)(nil)
@@ -40,7 +42,7 @@ func New(cacheLimit int) Cache {
 	return &lruCache{
 		dict:       make(map[string]*list.Element),
 		cacheLimit: cacheLimit,
-		ll:      list.New(),
+		ll:         list.New(),
 	}
 }
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -41,6 +41,13 @@ func New(cacheLimit int) Cache {
 }
 
 func (nc *abstractCache) Add(node Node) Node {
+	if e, ok := nc.dict[string(node.GetKey())]; ok {
+		nc.queue.MoveToFront(e)
+		old := e.Value
+		e.Value = node
+		return old.(Node)
+	}
+
 	elem := nc.queue.PushBack(node)
 	nc.dict[string(node.GetKey())] = elem
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,75 @@
+package cache
+
+import (
+	"container/list"
+)
+
+type Node interface {
+	GetKey() []byte
+}
+
+type Cache interface {
+	// Adds node to cache. If full and had to remove the oldest element,
+	// returns the oldest, otherwise nil.
+	Add(node Node) Node
+
+	// Has returns true if node with key exists in cache, false otherwise.
+	Has(key []byte) bool
+
+	// Remove removes node with key from cache. The removed node is returned.
+	// if not in cache, return nil.
+	Remove(key []byte) Node
+
+	// Len returns the cache length.
+	Len() int
+}
+
+type abstractCache struct {
+	dict       map[string]*list.Element // FastNode cache.
+	cacheLimit int                      // FastNode cache size limit in elements.
+	queue      *list.List               // LRU queue of cache elements. Used for deletion.
+}
+
+var _ Cache = (*abstractCache)(nil)
+
+func New(cacheLimit int) Cache {
+	return &abstractCache{
+		dict:       make(map[string]*list.Element),
+		cacheLimit: cacheLimit,
+		queue:      list.New(),
+	}
+}
+
+func (nc *abstractCache) Add(node Node) Node {
+	elem := nc.queue.PushBack(node)
+	nc.dict[string(node.GetKey())] = elem
+
+	if nc.queue.Len() > nc.cacheLimit {
+		oldest := nc.queue.Front()
+
+		return nc.remove(oldest)
+	}
+	return nil
+}
+
+func (c *abstractCache) Has(key []byte) bool {
+	_, ok := c.dict[string(key)]
+	return ok
+}
+
+func (nc *abstractCache) Len() int {
+	return nc.queue.Len()
+}
+
+func (c *abstractCache) Remove(key []byte) Node {
+	if elem, ok := c.dict[string(key)]; ok {
+		return c.remove(elem)
+	}
+	return nil
+}
+
+func (c *abstractCache) remove(e *list.Element) Node {
+	removed := c.queue.Remove(e).(Node)
+	delete(c.dict, string(removed.GetKey()))
+	return removed
+}

--- a/cache/cache_bench_test.go
+++ b/cache/cache_bench_test.go
@@ -1,0 +1,66 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/iavl/cache"
+	"github.com/cosmos/iavl/common"
+)
+
+func BenchmarkAdd(b *testing.B) {
+	b.ReportAllocs()
+	testcases := map[string]struct {
+		cacheLimit int
+		keySize    int
+	}{
+		"small - limit: 10K, key size - 10b": {
+			cacheLimit: 10000,
+			keySize:    10,
+		},
+		"med - limit: 100K, key size 20b": {
+			cacheLimit: 100000,
+			keySize:    20,
+		},
+		"large - limit: 1M, key size 30b": {
+			cacheLimit: 1000000,
+			keySize:    30,
+		},
+	}
+
+	for name, tc := range testcases {
+		cache := cache.New(tc.cacheLimit)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = cache.Add(&testNode{
+					key: randBytes(tc.keySize),
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkRemove(b *testing.B) {
+	b.ReportAllocs()
+
+	b.StopTimer()
+	cache := cache.New(1000)
+	existentKeyMirror := [][]byte{}
+	// Populate cache
+	for i := 0; i < 50; i++ {
+		key := randBytes(1000)
+
+		existentKeyMirror = append(existentKeyMirror, key)
+
+		cache.Add(&testNode{
+			key: key,
+		})
+	}
+
+	r := common.NewRand()
+
+	for i := 0; i < b.N; i++ {
+		key := existentKeyMirror[r.Intn(len(existentKeyMirror))]
+		b.ResetTimer()
+		_ = cache.Remove(key)
+	}
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,166 @@
+package cache_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cosmos/iavl/cache"
+	"github.com/stretchr/testify/require"
+)
+
+// expectedResult represents the expected result of each add/remove operation.
+// It can be noneRemoved or the index of the removed node in testNodes
+type expectedResult int
+const (
+	noneRemoved expectedResult = -1
+	// The rest represent the index of the removed node
+)
+
+// testNode is the node used for testing cache implementation
+type testNode struct {
+	key   []byte
+}
+
+func (tn *testNode) GetKey() []byte {
+	return tn.key
+}
+
+
+const (
+	testKey = "key"
+)
+
+var _ cache.Node = (*testNode)(nil)
+
+var (
+	testNodes = []cache.Node{
+		&testNode{
+			key: []byte(fmt.Sprintf("%s%d", testKey, 1)),
+		},
+		&testNode{
+			key: []byte(fmt.Sprintf("%s%d", testKey, 2)),
+		},
+		&testNode{
+			key: []byte(fmt.Sprintf("%s%d", testKey, 3)),
+		},
+	}
+)
+
+func Test_Cache_Add(t *testing.T) {
+	
+	type cacheOp struct {
+		testNodexIdx             int
+		expectedResult   expectedResult
+	}
+
+	testcases := map[string]struct {
+		cacheLimit          int
+		cacheOps            []cacheOp
+		expectedNodeIndexes []int // contents of the cache once test case completes represent by indexes in testNodes
+	}{
+		"add 1 node with 1 limit - added": {
+			cacheLimit: 1,
+			cacheOps: []cacheOp{
+				{
+					testNodexIdx: 0,
+					expectedResult: noneRemoved,
+				},
+			},
+			expectedNodeIndexes: []int{0},
+		},
+		"add 1 node with 0 limit - not added and return itself": {
+			cacheLimit: 0,
+			cacheOps: []cacheOp{
+				{
+					testNodexIdx: 0,
+					expectedResult: 0,
+				},
+			},
+		},
+		"add 3 nodes with 1 limit - first 2 removed": {
+			cacheLimit: 1,
+			cacheOps: []cacheOp{
+				{
+					testNodexIdx: 0,
+					expectedResult: noneRemoved,
+				},
+				{
+					testNodexIdx: 1,
+					expectedResult: 0,
+				},
+				{
+					testNodexIdx: 2,
+					expectedResult: 1,
+				},
+			},
+			expectedNodeIndexes: []int{2},
+		},
+		"add 3 nodes with 2 limit - first removed": {
+			cacheLimit: 2,
+			cacheOps: []cacheOp{
+				{
+					testNodexIdx: 0,
+					expectedResult: noneRemoved,
+				},
+				{
+					testNodexIdx: 1,
+					expectedResult: noneRemoved,
+				},
+				{
+					testNodexIdx: 2,
+					expectedResult: 0,
+				},
+			},
+			expectedNodeIndexes: []int{1, 2},
+		},
+		"add 3 nodes with 10 limit - non removed": {
+			cacheLimit: 10,
+			cacheOps: []cacheOp{
+				{
+					testNodexIdx: 0,
+					expectedResult: noneRemoved,
+				},
+				{
+					testNodexIdx: 1,
+					expectedResult: noneRemoved,
+				},
+				{
+					testNodexIdx: 2,
+					expectedResult: noneRemoved,
+				},
+			},
+			expectedNodeIndexes: []int{0, 1, 2},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			cache := cache.New(tc.cacheLimit)
+
+			expectedCurSize := 0
+
+			for _, op := range tc.cacheOps {
+
+				actualResult := cache.Add(testNodes[op.testNodexIdx])
+
+				expectedResult := op.expectedResult
+
+				if expectedResult == noneRemoved {
+					require.Nil(t, actualResult)
+					expectedCurSize++
+				} else {
+					require.NotNil(t, actualResult)
+					
+					// Here, op.expectedResult represents the index of the removed node in tc.cacheOps
+					require.Equal(t, testNodes[int(op.expectedResult)], actualResult)
+				}
+				require.Equal(t, expectedCurSize, cache.Len())
+			}
+
+			require.Equal(t, len(tc.expectedNodeIndexes), cache.Len())
+			for _, idx := range tc.expectedNodeIndexes {
+				require.True(t, cache.Has(testNodes[idx].GetKey()))
+			}
+		})
+	}
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,10 +1,12 @@
 package cache_test
 
 import (
+	"crypto/rand"
 	"fmt"
 	"testing"
 
 	"github.com/cosmos/iavl/cache"
+	// "github.com/cosmos/iavl/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -163,4 +165,75 @@ func Test_Cache_Add(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkAdd(b *testing.B) {
+	b.ReportAllocs()
+	testcases := map[string]struct {
+		cacheLimit          int
+		keySize int
+	}{
+		"small - limit: 10K, key size - 10b": {
+			cacheLimit: 10000,
+			keySize: 10,
+		},
+		"med - limit: 100K, key size 20b": {
+			cacheLimit: 100000,
+			keySize: 20,
+		},
+		"large - limit: 1M, key size 30b": {
+			cacheLimit: 1000000,
+			keySize: 30,
+		},
+	}
+
+	for name, tc := range testcases {
+		cache := cache.New(tc.cacheLimit)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				cache.Add(&testNode{
+					key: randBytes(tc.keySize),
+				})
+			}
+		})
+	}
+}
+
+// func BenchmarkRemove(b *testing.B) {
+// 	b.ReportAllocs()
+
+// 	b.StopTimer()
+// 	cache := cache.New(10000)
+// 	existentKeyMirror := [][]byte{}
+// 	// Populate cache
+// 	for i := 0; i < 10000; i++ {
+// 		key := randBytes(10)
+
+// 		existentKeyMirror = append(existentKeyMirror, key)
+
+// 		cache.Add(&testNode{
+// 			key: key,
+// 		})
+// 	}
+
+// 	// r := common.NewRand()
+
+// 	// var key []byte
+
+// 	for i := 0; i < b.N; i++ {
+// 		// b.StopTimer()
+// 		// key = existentKeyMirror[r.Intn(len(existentKeyMirror))]
+// 		// b.StartTimer()
+
+// 		_ = cache.Remove(randBytes(10))
+// 	}
+// }
+
+func randBytes(length int) []byte {
+	key := make([]byte, length)
+	// math.rand.Read always returns err=nil
+	// we do not need cryptographic randomness for this test:
+	//nolint:gosec
+	rand.Read(key)
+	return key
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -353,7 +353,9 @@ func BenchmarkRemove(b *testing.B) {
 func validateCacheContentsAfterTest(t *testing.T, tc testcase, cache cache.Cache) {
 	require.Equal(t, len(tc.expectedNodeIndexes), cache.Len())
 	for _, idx := range tc.expectedNodeIndexes {
-		require.True(t, cache.Has(testNodes[idx].GetKey()))
+		expectedNode := testNodes[idx]
+		require.True(t, cache.Has(expectedNode.GetKey()))
+		require.Equal(t, expectedNode, cache.Get(expectedNode.GetKey()))
 	}
 }
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/cosmos/iavl/cache"
-	"github.com/cosmos/iavl/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -290,64 +289,6 @@ func Test_Cache_Remove(t *testing.T) {
 
 			validateCacheContentsAfterTest(t, tc, cache)
 		})
-	}
-}
-
-func BenchmarkAdd(b *testing.B) {
-	b.ReportAllocs()
-	testcases := map[string]struct {
-		cacheLimit int
-		keySize    int
-	}{
-		"small - limit: 10K, key size - 10b": {
-			cacheLimit: 10000,
-			keySize:    10,
-		},
-		"med - limit: 100K, key size 20b": {
-			cacheLimit: 100000,
-			keySize:    20,
-		},
-		"large - limit: 1M, key size 30b": {
-			cacheLimit: 1000000,
-			keySize:    30,
-		},
-	}
-
-	for name, tc := range testcases {
-		cache := cache.New(tc.cacheLimit)
-		b.Run(name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = cache.Add(&testNode{
-					key: randBytes(tc.keySize),
-				})
-			}
-		})
-	}
-}
-
-func BenchmarkRemove(b *testing.B) {
-	b.ReportAllocs()
-
-	b.StopTimer()
-	cache := cache.New(1000)
-	existentKeyMirror := [][]byte{}
-	// Populate cache
-	for i := 0; i < 50; i++ {
-		key := randBytes(1000)
-
-		existentKeyMirror = append(existentKeyMirror, key)
-
-		cache.Add(&testNode{
-			key: key,
-		})
-	}
-
-	r := common.NewRand()
-
-	for i := 0; i < b.N; i++ {
-		key := existentKeyMirror[r.Intn(len(existentKeyMirror))]
-		b.ResetTimer()
-		_ = cache.Remove(key)
 	}
 }
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -13,6 +13,7 @@ import (
 // expectedResult represents the expected result of each add/remove operation.
 // It can be noneRemoved or the index of the removed node in testNodes
 type expectedResult int
+
 const (
 	noneRemoved expectedResult = -1
 	// The rest represent the index of the removed node
@@ -20,16 +21,16 @@ const (
 
 // testNode is the node used for testing cache implementation
 type testNode struct {
-	key   []byte
+	key []byte
 }
 
 type cacheOp struct {
-	testNodexIdx             int
-	expectedResult   expectedResult
+	testNodexIdx   int
+	expectedResult expectedResult
 }
 
 type testcase struct {
-	setup func(cache.Cache)
+	setup               func(cache.Cache)
 	cacheLimit          int
 	cacheOps            []cacheOp
 	expectedNodeIndexes []int // contents of the cache once test case completes represent by indexes in testNodes
@@ -65,7 +66,7 @@ func Test_Cache_Add(t *testing.T) {
 			cacheLimit: 1,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: noneRemoved,
 				},
 			},
@@ -75,11 +76,11 @@ func Test_Cache_Add(t *testing.T) {
 			cacheLimit: 2,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: noneRemoved,
 				},
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: 0,
 				},
 			},
@@ -89,7 +90,7 @@ func Test_Cache_Add(t *testing.T) {
 			cacheLimit: 0,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: 0,
 				},
 			},
@@ -98,15 +99,15 @@ func Test_Cache_Add(t *testing.T) {
 			cacheLimit: 1,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: noneRemoved,
 				},
 				{
-					testNodexIdx: 1,
+					testNodexIdx:   1,
 					expectedResult: 0,
 				},
 				{
-					testNodexIdx: 2,
+					testNodexIdx:   2,
 					expectedResult: 1,
 				},
 			},
@@ -116,15 +117,15 @@ func Test_Cache_Add(t *testing.T) {
 			cacheLimit: 2,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: noneRemoved,
 				},
 				{
-					testNodexIdx: 1,
+					testNodexIdx:   1,
 					expectedResult: noneRemoved,
 				},
 				{
-					testNodexIdx: 2,
+					testNodexIdx:   2,
 					expectedResult: 0,
 				},
 			},
@@ -134,15 +135,15 @@ func Test_Cache_Add(t *testing.T) {
 			cacheLimit: 10,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: noneRemoved,
 				},
 				{
-					testNodexIdx: 1,
+					testNodexIdx:   1,
 					expectedResult: noneRemoved,
 				},
 				{
-					testNodexIdx: 2,
+					testNodexIdx:   2,
 					expectedResult: noneRemoved,
 				},
 			},
@@ -167,7 +168,7 @@ func Test_Cache_Add(t *testing.T) {
 					expectedCurSize++
 				} else {
 					require.NotNil(t, actualResult)
-					
+
 					// Here, op.expectedResult represents the index of the removed node in tc.cacheOps
 					require.Equal(t, testNodes[int(op.expectedResult)], actualResult)
 				}
@@ -185,7 +186,7 @@ func Test_Cache_Remove(t *testing.T) {
 			cacheLimit: 0,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: noneRemoved,
 				},
 			},
@@ -198,7 +199,7 @@ func Test_Cache_Remove(t *testing.T) {
 			cacheLimit: 1,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: noneRemoved,
 				},
 			},
@@ -212,7 +213,7 @@ func Test_Cache_Remove(t *testing.T) {
 			cacheLimit: 1,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: 0,
 				},
 			},
@@ -225,11 +226,11 @@ func Test_Cache_Remove(t *testing.T) {
 			cacheLimit: 1,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: 0,
 				},
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: noneRemoved,
 				},
 			},
@@ -244,15 +245,15 @@ func Test_Cache_Remove(t *testing.T) {
 			cacheLimit: 3,
 			cacheOps: []cacheOp{
 				{
-					testNodexIdx: 2,
+					testNodexIdx:   2,
 					expectedResult: 2,
 				},
 				{
-					testNodexIdx: 0,
+					testNodexIdx:   0,
 					expectedResult: 0,
 				},
 				{
-					testNodexIdx: 1,
+					testNodexIdx:   1,
 					expectedResult: 1,
 				},
 			},
@@ -280,7 +281,7 @@ func Test_Cache_Remove(t *testing.T) {
 				} else {
 					expectedCurSize--
 					require.NotNil(t, actualResult)
-					
+
 					// Here, op.expectedResult represents the index of the removed node in tc.cacheOps
 					require.Equal(t, testNodes[int(op.expectedResult)], actualResult)
 				}
@@ -295,20 +296,20 @@ func Test_Cache_Remove(t *testing.T) {
 func BenchmarkAdd(b *testing.B) {
 	b.ReportAllocs()
 	testcases := map[string]struct {
-		cacheLimit          int
-		keySize int
+		cacheLimit int
+		keySize    int
 	}{
 		"small - limit: 10K, key size - 10b": {
 			cacheLimit: 10000,
-			keySize: 10,
+			keySize:    10,
 		},
 		"med - limit: 100K, key size 20b": {
 			cacheLimit: 100000,
-			keySize: 20,
+			keySize:    20,
 		},
 		"large - limit: 1M, key size 30b": {
 			cacheLimit: 1000000,
-			keySize: 30,
+			keySize:    30,
 		},
 	}
 

--- a/fast_node.go
+++ b/fast_node.go
@@ -16,7 +16,7 @@ type FastNode struct {
 	value                []byte
 }
 
-var _ cache.Node = &FastNode{}
+var _ cache.Node = (*FastNode)(nil)
 
 // NewFastNode returns a new fast node from a value and version.
 func NewFastNode(key []byte, value []byte, version int64) *FastNode {

--- a/fast_node.go
+++ b/fast_node.go
@@ -1,8 +1,10 @@
 package iavl
 
 import (
-	"github.com/pkg/errors"
 	"io"
+
+	"github.com/cosmos/iavl/cache"
+	"github.com/pkg/errors"
 )
 
 // NOTE: This file favors int64 as opposed to int for size/counts.
@@ -13,6 +15,8 @@ type FastNode struct {
 	versionLastUpdatedAt int64
 	value                []byte
 }
+
+var _ cache.Node = &FastNode{}
 
 // NewFastNode returns a new fast node from a value and version.
 func NewFastNode(key []byte, value []byte, version int64) *FastNode {
@@ -43,6 +47,10 @@ func DeserializeFastNode(key []byte, buf []byte) (*FastNode, error) {
 	}
 
 	return fastNode, nil
+}
+
+func (fn *FastNode) GetKey() []byte {
+	return fn.key
 }
 
 func (node *FastNode) encodedSize() int {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -577,7 +577,7 @@ func (tree *MutableTree) enableFastStorageAndCommit() error {
 		close(done)
 	}()
 
-	go func ()  {
+	go func() {
 		timer := time.NewTimer(time.Second)
 		var m runtime.MemStats
 
@@ -585,7 +585,7 @@ func (tree *MutableTree) enableFastStorageAndCommit() error {
 			// Sample the current memory usage
 			runtime.ReadMemStats(&m)
 
-			if m.Alloc > 4 * 1024 * 1024 * 1024 {
+			if m.Alloc > 4*1024*1024*1024 {
 				// If we are using more than 4GB of memory, we should trigger garbage collection
 				// to free up some memory.
 				runtime.GC()

--- a/node.go
+++ b/node.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 
+	"github.com/cosmos/iavl/cache"
 	"github.com/pkg/errors"
 )
 
@@ -27,6 +28,8 @@ type Node struct {
 	height    int8
 	persisted bool
 }
+
+var _ cache.Node = (*Node)(nil)
 
 // NewNode returns a new node from a key, value and version.
 func NewNode(key []byte, value []byte, version int64) *Node {
@@ -103,6 +106,10 @@ func MakeNode(buf []byte) (*Node, error) {
 		node.rightHash = rightHash
 	}
 	return node, nil
+}
+
+func (n *Node) GetKey() []byte {
+	return n.hash
 }
 
 // String returns a string representation of the node.

--- a/nodedb.go
+++ b/nodedb.go
@@ -2,7 +2,6 @@ package iavl
 
 import (
 	"bytes"
-	"container/list"
 	"crypto/sha256"
 	"fmt"
 	"math"
@@ -74,13 +73,9 @@ type nodeDB struct {
 	opts           Options          // Options to customize for pruning/writing
 	versionReaders map[int64]uint32 // Number of active version readers
 	storageVersion string           // Storage version
-
 	latestVersion  int64
-	nodeCache      map[string]*list.Element // Node cache.
-	nodeCacheSize  int                      // Node cache size limit in elements.
-	nodeCacheQueue *list.List               // LRU queue of cache elements. Used for deletion.
-
-	fastNodeCache cache.Cache
+	nodeCache      cache.Cache
+	fastNodeCache  cache.Cache
 }
 
 func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
@@ -96,16 +91,14 @@ func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
 	}
 
 	return &nodeDB{
-		db:                 db,
-		batch:              db.NewBatch(),
-		opts:               *opts,
-		latestVersion:      0, // initially invalid
-		nodeCache:          make(map[string]*list.Element),
-		nodeCacheSize:      cacheSize,
-		nodeCacheQueue:     list.New(),
-		fastNodeCache:      cache.New(100000),
-		versionReaders:     make(map[int64]uint32, 8),
-		storageVersion:     string(storeVersion),
+		db:             db,
+		batch:          db.NewBatch(),
+		opts:           *opts,
+		latestVersion:  0, // initially invalid
+		nodeCache:      cache.New(cacheSize),
+		fastNodeCache:  cache.New(100000),
+		versionReaders: make(map[int64]uint32, 8),
+		storageVersion: string(storeVersion),
 	}
 }
 
@@ -120,10 +113,8 @@ func (ndb *nodeDB) GetNode(hash []byte) *Node {
 	}
 
 	// Check the cache.
-	if elem, ok := ndb.nodeCache[string(hash)]; ok {
-		// Already exists. Move to back of nodeCacheQueue.
-		ndb.nodeCacheQueue.MoveToBack(elem)
-		return elem.Value.(*Node)
+	if cachedNode := ndb.nodeCache.Get(hash); cachedNode != nil {
+		return cachedNode.(*Node)
 	}
 
 	// Doesn't exist, load.
@@ -142,7 +133,7 @@ func (ndb *nodeDB) GetNode(hash []byte) *Node {
 
 	node.hash = hash
 	node.persisted = true
-	ndb.cacheNode(node)
+	ndb.nodeCache.Add(node)
 
 	return node
 }
@@ -206,7 +197,7 @@ func (ndb *nodeDB) SaveNode(node *Node) {
 	}
 	debug("BATCH SAVE %X %p\n", node.hash, node)
 	node.persisted = true
-	ndb.cacheNode(node)
+	ndb.nodeCache.Add(node)
 }
 
 // SaveNode saves a FastNode to disk and add to cache.
@@ -429,7 +420,7 @@ func (ndb *nodeDB) DeleteVersionsFrom(version int64) error {
 			if err = ndb.batch.Delete(ndb.nodeKey(hash)); err != nil {
 				return err
 			}
-			ndb.uncacheNode(hash)
+			ndb.nodeCache.Remove(hash)
 		} else if toVersion >= version-1 {
 			if err := ndb.batch.Delete(key); err != nil {
 				return err
@@ -518,7 +509,7 @@ func (ndb *nodeDB) DeleteVersionsRange(fromVersion, toVersion int64) error {
 				if err := ndb.batch.Delete(ndb.nodeKey(hash)); err != nil {
 					panic(err)
 				}
-				ndb.uncacheNode(hash)
+				ndb.nodeCache.Remove(hash)
 			} else {
 				ndb.saveOrphan(hash, from, predecessor)
 			}
@@ -577,7 +568,7 @@ func (ndb *nodeDB) deleteNodesFrom(version int64, hash []byte) error {
 			return err
 		}
 
-		ndb.uncacheNode(hash)
+		ndb.nodeCache.Remove(hash)
 	}
 
 	return nil
@@ -638,7 +629,7 @@ func (ndb *nodeDB) deleteOrphans(version int64) error {
 			if err := ndb.batch.Delete(ndb.nodeKey(hash)); err != nil {
 				return err
 			}
-			ndb.uncacheNode(hash)
+			ndb.nodeCache.Remove(hash)
 		} else {
 			debug("MOVE predecessor:%v fromVersion:%v toVersion:%v %X\n", predecessor, fromVersion, toVersion, hash)
 			ndb.saveOrphan(hash, fromVersion, predecessor)
@@ -795,26 +786,6 @@ func (ndb *nodeDB) getFastIterator(start, end []byte, ascending bool) (dbm.Itera
 	}
 
 	return ndb.db.ReverseIterator(startFormatted, endFormatted)
-}
-
-func (ndb *nodeDB) uncacheNode(hash []byte) {
-	if elem, ok := ndb.nodeCache[string(hash)]; ok {
-		ndb.nodeCacheQueue.Remove(elem)
-		delete(ndb.nodeCache, string(hash))
-	}
-}
-
-// Add a node to the cache and pop the least recently used node if we've
-// reached the cache size limit.
-func (ndb *nodeDB) cacheNode(node *Node) {
-	elem := ndb.nodeCacheQueue.PushBack(node)
-	ndb.nodeCache[string(node.hash)] = elem
-
-	if ndb.nodeCacheQueue.Len() > ndb.nodeCacheSize {
-		oldest := ndb.nodeCacheQueue.Front()
-		hash := ndb.nodeCacheQueue.Remove(oldest).(*Node).hash
-		delete(ndb.nodeCache, string(hash))
-	}
 }
 
 // Write to disk.

--- a/nodedb.go
+++ b/nodedb.go
@@ -29,6 +29,7 @@ const (
 	// Using semantic versioning: https://semver.org/
 	defaultStorageVersionValue = "1.0.0"
 	fastStorageVersionValue    = "1.1.0"
+	fastNodeCacheLimit = 100000
 )
 
 var (
@@ -96,7 +97,7 @@ func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
 		opts:           *opts,
 		latestVersion:  0, // initially invalid
 		nodeCache:      cache.New(cacheSize),
-		fastNodeCache:  cache.New(100000),
+		fastNodeCache:  cache.New(fastNodeCacheLimit),
 		versionReaders: make(map[int64]uint32, 8),
 		storageVersion: string(storeVersion),
 	}

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -418,11 +418,11 @@ func assertFastNodeCacheIsLive(t *testing.T, tree *MutableTree, mirror map[strin
 		return
 	}
 
-	for key, cacheElem := range tree.ndb.fastNodeCache {
-		liveFastNode := mirror[key]
-
-		require.NotNil(t, liveFastNode, "cached fast node must be in live tree")
-		require.Equal(t, liveFastNode, string(cacheElem.Value.(*FastNode).value), "cached fast node's value must be equal to live state value")
+	require.Equal(t, len(mirror), tree.ndb.fastNodeCache.Len())
+	for k, v := range mirror {
+		require.True(t, tree.ndb.fastNodeCache.Has([]byte(k)), "cached fast node must be in live tree")
+		mirrorNode := tree.ndb.fastNodeCache.Get([]byte(k))
+		require.Equal(t, []byte(v), mirrorNode.(*FastNode).value, "cached fast node's value must be equal to live state value")
 	}
 }
 


### PR DESCRIPTION
**Context**
- See here: https://github.com/osmosis-labs/osmosis/issues/1163
- To sum up:
  * better abstraction for cache to eventually enable the limit by bytes as opposed to the number of nodes
  * unit tested cache
  * avoid caching nodes with the same key (the old one is now replaced)
  * cache adapted from: https://github.com/golang/groupcache/blob/master/lru/lru.go

**Benchstat**
```
name                                                                 old time/op    new time/op    delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-4    4.22µs ± 9%    4.15µs ± 6%     ~     (p=1.000 n=5+5)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-4    15.3µs ±11%    16.6µs ± 6%     ~     (p=0.056 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-fast-4                     566ns ± 8%     613ns ±11%     ~     (p=0.222 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-slow-4                    21.2µs ± 5%    21.0µs ± 4%     ~     (p=0.690 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-4                     78.0ms ± 6%    81.1ms ±11%     ~     (p=0.548 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-4                      1.79s ±13%     1.90s ±11%     ~     (p=0.222 n=5+5)
Medium/goleveldb-100000-100-16-40/update-4                              233µs ±15%     203µs ± 8%  -12.78%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/block-4                              29.0ms ± 4%    25.8ms ±10%  -11.04%  (p=0.016 n=5+5)

name                                                                 old alloc/op   new alloc/op   delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-4      814B ± 0%      814B ± 0%     ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-4    1.41kB ± 1%    1.41kB ± 0%     ~     (p=1.000 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-fast-4                     0.00B          0.00B          ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-slow-4                    1.99kB ± 1%    2.00kB ± 1%     ~     (p=0.460 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-4                     29.3MB ± 0%    29.3MB ± 0%     ~     (p=0.381 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-4                      276MB ± 0%     276MB ± 0%   +0.02%  (p=0.029 n=4+4)
Medium/goleveldb-100000-100-16-40/update-4                             47.4kB ± 2%    46.5kB ± 4%     ~     (p=0.151 n=5+5)
Medium/goleveldb-100000-100-16-40/block-4                              5.65MB ± 2%    5.41MB ± 2%   -4.27%  (p=0.008 n=5+5)

name                                                                 old allocs/op  new allocs/op  delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-4      16.0 ± 0%      16.0 ± 0%     ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-4      24.0 ± 0%      24.0 ± 0%     ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-fast-4                      0.00           0.00          ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-slow-4                      34.0 ± 0%      34.0 ± 0%     ~     (all equal)
Medium/goleveldb-100000-100-16-40/iteration-fast-4                       523k ± 0%      523k ± 0%     ~     (p=0.484 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-4                      4.71M ± 0%     4.71M ± 0%   +0.01%  (p=0.029 n=4+4)
Medium/goleveldb-100000-100-16-40/update-4                                502 ± 9%       482 ± 6%     ~     (p=0.421 n=5+5)
Medium/goleveldb-100000-100-16-40/block-4                               62.1k ± 3%     59.6k ± 2%   -4.05%  (p=0.016 n=5+5)
```